### PR TITLE
Correctly refer to the app in the 'About' and Privacy Policy pages

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -140,7 +140,7 @@
         <a href="https://github.com/michellexliu/receiptify">here</a>.
       </p>
       <br />
-      <h2>Will Spotify steal my data?</h2>
+      <h2>Will Receiptify steal my data?</h2>
       <p>
         In short: NO! For more information, view Receiptify's
         <a href="privacy.html">Privacy Policy</a>.

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -187,7 +187,7 @@
       <div data-fuse-privacy-tool></div>
       <br />
       <p>
-        Spotify was developed as an open source app powered by the
+        Receiptify was developed as an open source app powered by the
         Spotify/Last.fm/Apple Music Web API. By choosing to use this app, you
         agree to the use of your Spotify account username and data for your top
         artists and tracks.
@@ -200,7 +200,7 @@
       </p>
       <br />
       <p>
-        Although you can rest assured that your data is not being stored or used
+        Although you can rest assured that your Spotify data is not being stored or used
         maliciously, if you would like to revoke Receiptify's permissions, you
         can visit
         <a


### PR DESCRIPTION
Also clarifies that the provided instructions in the privacy policy for revoking access are for Spotify data