### PR TITLE
chore: use the current year in the receipt

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -470,7 +470,7 @@
               </tr>
             </table>
             <p class='date'>
-              CARD #: **** **** **** 2023
+              CARD #: **** **** **** {{currentYear}}
             </p>
             <p class='date'>
               AUTH CODE: 123421

--- a/public/lastfm.html
+++ b/public/lastfm.html
@@ -278,7 +278,7 @@
                 </tr>
               </table>
               <p class='date'>
-                CARD #: **** **** **** 2023
+                CARD #: **** **** **** {{currentYear}}
               </p>
               <p class='date'>
                 AUTH CODE: 123421

--- a/public/server.js
+++ b/public/server.js
@@ -487,6 +487,10 @@ const newTab = () => {
   });
 };
 
+const getCurrentYear = () => {
+  return TODAY.getFullYear();
+}
+
 const getMonthYear = () => {
   // Create a new Date object for the current date and time
 

--- a/public/server.js
+++ b/public/server.js
@@ -683,6 +683,7 @@ const displayReceipt = (response, stats) => {
     itemCount: tracksFormatted.length,
     isStats: type === 'stats',
     isInternational: font === 'international',
+    currentYear: getCurrentYear(),
   });
 
   if (type === 'build-receipt') {

--- a/views/spotify.handlebars
+++ b/views/spotify.handlebars
@@ -80,7 +80,7 @@
           </tr>
         </table>
         <p class="date">
-          CARD #: **** **** **** 2023
+          CARD #: **** **** **** {{currentYear}}
         </p>
         <p class="date">
           AUTH CODE: 123421
@@ -159,7 +159,7 @@
           </tr>
         </table>
         <p class="date">
-          CARD #: **** **** **** 2023
+          CARD #: **** **** **** {{currentYear}}
         </p>
         <p class="date">
           AUTH CODE: 123421

--- a/views/spotifyReceipt.handlebars
+++ b/views/spotifyReceipt.handlebars
@@ -82,7 +82,7 @@
               </tr>
             </table>
             <p class="date">
-              CARD #: **** **** **** 2023
+              CARD #: **** **** **** {{currentYear}}
             </p>
             <p class="date">
               AUTH CODE: 123421


### PR DESCRIPTION
this PR replaces the "2023" that is hard-coded with the current year